### PR TITLE
🐛 Insert lodash call for empty response speech

### DIFF
--- a/packages/jovo-model-dialogflow/src/JovoModelDialogflow.ts
+++ b/packages/jovo-model-dialogflow/src/JovoModelDialogflow.ts
@@ -767,7 +767,7 @@ export class JovoModelDialogflow extends JovoModel {
                             []
                         );
 
-                        if (message.speech.length > 0) {
+                        if (_.get(message, 'speech', '').length > 0) {
                             jovoIntentDialogflowMessages.push(message);
                             _.set(
                                 jovoIntent,


### PR DESCRIPTION
Fixes the bug described here: https://github.com/jovotech/jovo-cli/issues/135