### PR TITLE
:rewind: Reverse alexa-specific intents back to array

### DIFF
--- a/packages/jovo-model-alexa/src/JovoModelAlexa.ts
+++ b/packages/jovo-model-alexa/src/JovoModelAlexa.ts
@@ -50,13 +50,11 @@ export class JovoModelAlexa extends JovoModel {
       _set(jovoModel, 'alexa.interactionModel.dialog', _get(inputData, 'interactionModel.dialog'));
     }
 
-    const alexaIntents: Record<string, Intent> = {};
+    const alexaIntents: Intent[] = [];
     const jovoIntents: Record<string, Intent> = {};
     for (const intent of _get(inputData, 'interactionModel.languageModel.intents')) {
       if (_startsWith(intent.name, BUILTIN_PREFIX)) {
-        const intentName: string = intent.name;
-        delete intent.name;
-        alexaIntents[intentName] = intent;
+        alexaIntents.push(intent);
       } else {
         const jovoIntent: Intent = {
           phrases: intent.samples,


### PR DESCRIPTION
## Proposed changes
This PR fixes a bug that was introduced in jovotech/jovo-model/pull/45 which also converted Alexa-specific intents to an object instead of an array. 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed