### PR TITLE
feat(google): add support for list parameter on entity

### DIFF
--- a/packages/jovo-model-google/src/Interfaces.ts
+++ b/packages/jovo-model-google/src/Interfaces.ts
@@ -2,6 +2,7 @@ export interface GoogleActionParameter {
   name: string;
   type: {
     name: string;
+    list?: boolean;
   };
 }
 

--- a/packages/jovo-model-google/src/JovoModelGoogle.ts
+++ b/packages/jovo-model-google/src/JovoModelGoogle.ts
@@ -96,6 +96,7 @@ export class JovoModelGoogle extends JovoModel {
             const matched: string = match[0];
             const entity: string = match[1];
             let type: string | undefined;
+            let isList = false;
 
             // Get entity type for current entity
             const entities = JovoModelHelper.getEntities(model, intentKey);
@@ -112,6 +113,8 @@ export class JovoModelGoogle extends JovoModel {
                 }
 
                 type = entityData.type;
+                // @ts-ignore
+                isList = entityData.list ?? false;
               }
             }
 
@@ -167,6 +170,7 @@ export class JovoModelGoogle extends JovoModel {
                 name: entity,
                 type: {
                   name: type,
+                  list: isList,
                 },
               });
             }


### PR DESCRIPTION
## Proposed changes

I'm working on a Jovo project with Google Assistant. I noticed the Actions Builder has a flag to determine if an input is a list or not.

<img width="1316" alt="Screenshot 2022-03-07 at 17 23 36" src="https://user-images.githubusercontent.com/2750752/157074861-749f35a9-dfb3-49b5-80ae-892c4a067de1.png">

When "getting" the config with `jovo get:platform` I saw the parameter being returned as `list: true` if it was present. But when I pass this parameter inside my JovoModel, it got ignored by the transformer/validator.

With this change, you can pass an optional `list: boolean` parameter in the JovoModel, and the `jovo build:platform` command will properly use this value.

```
  "intents": {
    "FeedbackScoreInputIntent": {
       "phrases": ...
       "entities": { "score": { "type": "FeedbackScoreType", "list": true } }
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed