### PR TITLE
feat(google): allow translatable entity synonyms

### DIFF
--- a/packages/jovo-model-google/src/JovoModelGoogle.ts
+++ b/packages/jovo-model-google/src/JovoModelGoogle.ts
@@ -250,7 +250,7 @@ export class JovoModelGoogle extends JovoModel {
         path.push(`${name}.yaml`);
 
         returnFiles.push({
-          path: path,
+          path,
           content: yaml.stringify(content),
         });
       }

--- a/packages/jovo-model-google/src/JovoModelGoogle.ts
+++ b/packages/jovo-model-google/src/JovoModelGoogle.ts
@@ -243,8 +243,14 @@ export class JovoModelGoogle extends JovoModel {
       }
 
       for (const [name, content] of Object.entries(googleProps)) {
+        const path = ['custom', key];
+        if (key !== 'global' && locale !== this.defaultLocale) {
+          path.push(locale);
+        }
+        path.push(`${name}.yaml`);
+
         returnFiles.push({
-          path: ['custom', key, `${name}.yaml`],
+          path: path,
           content: yaml.stringify(content),
         });
       }


### PR DESCRIPTION
## Proposed changes

Let's say you have a multilingual Google Assistant app (with language `nl` as a default language, and `en`) with an app that only has 1 intent: to capture a score that a user can give.

This is the `models/nl.json` file
```json
{
  "intents": {
    "ScoreInputIntent": {
      "phrases": ["{score}", "Ik vind het {score}"],
      "entities": { "score": { "type": "ScoreType" } }
    }
  },
  "googleAssistant": {
    "custom": {
      "global": {
        "actions.intent.MAIN": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_INPUT_1": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_INPUT_2": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_INPUT_FINAL": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_MATCH_1": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_MATCH_2": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_MATCH_FINAL": { "handler": { "webhookHandler": "Jovo" } }
      },
      "types": {
        "ScoreType": {
          "synonym": {
            "entities": {
              "1": { "synonyms": ["1", "slecht"] },
              "2": { "synonyms": ["2", "middelmatig"] },
              "3": { "synonyms": ["3", "goed"] }
            },
            "matchType": "EXACT_MATCH"
          }
        }
      }
    }
  }
}

```

In the english model `models/en.json`, you would have something like this

```json
{
  "intents": {
    "ScoreInputIntent": {
      "phrases": ["{score}", "I think it's {score}"],
      "entities": { "score": { "type": "ScoreType" } }
    }
  },
  "googleAssistant": {
    "custom": {
      "global": {
        "actions.intent.MAIN": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_INPUT_1": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_INPUT_2": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_INPUT_FINAL": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_MATCH_1": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_MATCH_2": { "handler": { "webhookHandler": "Jovo" } },
        "actions.intent.NO_MATCH_FINAL": { "handler": { "webhookHandler": "Jovo" } }
      },
      "types": {
        "ScoreType": {
          "synonym": {
            "entities": {
              "1": { "synonyms": ["1", "bad"] },
              "2": { "synonyms": ["2", "mediocre"] },
              "3": { "synonyms": ["3", "good"] }
            }
          }
        }
      }
    }
  }
}
```

With the current code/setup, the `jovo build`-platform doesn't take the secondary languages into account and only generates a `build/[STAGE]/platform.googleAssistant/custom/types/ScoreType.yaml`
```yaml
"synonym":
  "entities":
    "1":
      "synonyms":
        - "1"
        - "slecht"
    "2":
      "synonyms":
        - "2"
        - "middelmatig"
    "3":
      "synonyms":
        - "3"
        - "goed"
  "matchType": "EXACT_MATCH"
```

Where we need a `build/[STAGE]/platform.googleAssistant/custom/types/en/ScoreType.yaml` as well with the translations for the English model
```yaml
"synonym":
  "entities":
    "1":
      "synonyms":
        - "1"
        - "bad"
    "2":
      "synonyms":
        - "2"
        - "mediocre"
    "3":
      "synonyms":
        - "3"
        - "good"
```

With this pull request the desired behaviour is introduced. When you then deploy the code to Actions on Google, the translations are available in the Console.




## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed