### PR TITLE
:sparkles: Add alexa name-free interaction support

### DIFF
--- a/packages/jovo-model-alexa/src/JovoModelAlexa.ts
+++ b/packages/jovo-model-alexa/src/JovoModelAlexa.ts
@@ -330,6 +330,15 @@ export class JovoModelAlexa extends JovoModel {
       _set(alexaModel, 'interactionModel.dialog', _get(model, 'alexa.interactionModel.dialog'));
     }
 
+    // name-free interaction
+    if (_get(model, 'alexa.interactionModel._nameFreeInteraction')) {
+      _set(
+        alexaModel,
+        'interactionModel._nameFreeInteraction',
+        _get(model, 'alexa.interactionModel._nameFreeInteraction')
+      );
+    }
+
     // types
     if (JovoModelHelper.hasEntityTypes(model)) {
       const entityTypes = JovoModelHelper.getEntityTypes(model);


### PR DESCRIPTION
## Proposed changes
This adds support for the `interactionModel._nameFreeInteraction` property to be added to the resulting Alexa Language Model. 

I first thought that the object in the `alexa` section of the jovo language model would just be merged into the end result of the non platform specific build result. Is there a reason, why this is not the case? 

Instead of going this way though, this follows the current approach of basically copy and pasting the `nameFreeInteraction` from `model.alexa.interactionModel` to `alexaModel.interactionModel`. 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed